### PR TITLE
Fix missing symbol error

### DIFF
--- a/cpp/include/cuml/experimental/fil/detail/infer/cpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer/cpu.hpp
@@ -116,7 +116,7 @@ std::enable_if_t<D==raft_proto::device_type::cpu, void> infer(
  * the above template. Alternatively, if we see some way in which the above is
  * actually an abuse of SFINAE that was accidentally permitted by gcc 9, the
  * root cause should be corrected. */
-#ifndef CUML_CUDA_ENABLED
+#ifndef CUML_ENABLE_GPU
 template<
   raft_proto::device_type D,
   bool has_categorical_nodes,
@@ -140,7 +140,7 @@ std::enable_if_t<D==raft_proto::device_type::gpu, void> infer(
 ) {
   throw raft_proto::gpu_unsupported("Tried to use GPU inference in CPU-only build");
 }
-#endif
+#endif  // CUML_ENABLE_GPU
 
 /* This macro is invoked here to declare all standard specializations of this
  * template as extern. This ensures that this (relatively complex) code is

--- a/cpp/include/cuml/experimental/fil/detail/infer/gpu.hpp
+++ b/cpp/include/cuml/experimental/fil/detail/infer/gpu.hpp
@@ -30,7 +30,7 @@ namespace inference {
 
 /* Note(wphicks): This ifdef is a workaround for a possible gcc 11
  * compiler bug. See cpu.hpp for more details */
-#ifdef CUML_CUDA_ENABLED
+#ifdef CUML_ENABLE_GPU
 /* The CUDA-free header declaration of the GPU infer template */
 template<
   raft_proto::device_type D,
@@ -53,7 +53,7 @@ std::enable_if_t<D==raft_proto::device_type::gpu, void> infer(
   raft_proto::device_id<D> device=raft_proto::device_id<D>{},
   raft_proto::cuda_stream stream=raft_proto::cuda_stream{}
 );
-#endif
+#endif  // CUML_ENABLE_GPU
 
 }
 }

--- a/python/cuml/tests/experimental/test_filex.py
+++ b/python/cuml/tests/experimental/test_filex.py
@@ -133,7 +133,7 @@ def _build_and_save_xgboost(
     [unit_param(1), unit_param(5), quality_param(50), stress_param(90)],
 )
 @pytest.mark.parametrize("n_classes", [2, 5, 25])
-@pytest.mark.skipif(has_xgboost(), reason="need to install xgboost")
+@pytest.mark.skipif(has_xgboost() is False, reason="need to install xgboost")
 def test_fil_classification(
     train_device,
     infer_device,


### PR DESCRIPTION
CMakeLists.txt defines macro `CUML_ENABLE_GPU`, not `CUML_CUDA_ENABLED`